### PR TITLE
Add ParamNames

### DIFF
--- a/Source/ParamNames.h
+++ b/Source/ParamNames.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace ParamNames
+{
+    const juce::String size       { "size" };
+    const juce::String damp       { "damp" };
+    const juce::String width      { "width" };
+    const juce::String dryWet     { "dw" };
+    const juce::String freeze     { "freeze" };
+}

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -8,15 +8,16 @@
 
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include "ParamNames.h"
 
 //==============================================================================
 SimpleReverbAudioProcessorEditor::SimpleReverbAudioProcessorEditor (SimpleReverbAudioProcessor& p, juce::UndoManager& um)
     : AudioProcessorEditor (&p), audioProcessor (p), undoManager (um),
-      sizeDialAttachment     (audioProcessor.apvts, "size",   sizeDial),
-      dampDialAttachment     (audioProcessor.apvts, "damp",   dampDial),
-      widthDialAttachment    (audioProcessor.apvts, "width",  widthDial),
-      dwDialAttachment       (audioProcessor.apvts, "dw",     dwDial),
-      freezeButtonAttachment (audioProcessor.apvts, "freeze", freezeButton)
+      sizeDialAttachment     (audioProcessor.apvts, ParamNames::size,   sizeDial),
+      dampDialAttachment     (audioProcessor.apvts, ParamNames::damp,   dampDial),
+      widthDialAttachment    (audioProcessor.apvts, ParamNames::width,  widthDial),
+      dwDialAttachment       (audioProcessor.apvts, ParamNames::dryWet, dwDial),
+      freezeButtonAttachment (audioProcessor.apvts, ParamNames::freeze, freezeButton)
 {
     juce::LookAndFeel::setDefaultLookAndFeel (&lnf);
     setWantsKeyboardFocus (true);
@@ -28,16 +29,16 @@ SimpleReverbAudioProcessorEditor::SimpleReverbAudioProcessorEditor (SimpleReverb
     getConstrainer()->setFixedAspectRatio (ratio);
     setSize (560, 280);
 
-    sizeLabel.setText ("size", juce::NotificationType::dontSendNotification);
+    sizeLabel.setText (ParamNames::size, juce::NotificationType::dontSendNotification);
     sizeLabel.attachToComponent (&sizeDial, false);
 
-    dampLabel.setText ("damp", juce::NotificationType::dontSendNotification);
+    dampLabel.setText (ParamNames::damp, juce::NotificationType::dontSendNotification);
     dampLabel.attachToComponent (&dampDial, false);
 
-    widthLabel.setText ("width", juce::NotificationType::dontSendNotification);
+    widthLabel.setText (ParamNames::width, juce::NotificationType::dontSendNotification);
     widthLabel.attachToComponent (&widthDial, false);
 
-    dwLabel.setText ("dw", juce::NotificationType::dontSendNotification);
+    dwLabel.setText (ParamNames::dryWet, juce::NotificationType::dontSendNotification);
     dwLabel.attachToComponent (&dwDial, false);
 
     freezeButton.setButtonText (juce::String (juce::CharPointer_UTF8 ("∞")));

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -8,6 +8,7 @@
 
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include "ParamNames.h"
 
 //==============================================================================
 SimpleReverbAudioProcessor::SimpleReverbAudioProcessor()
@@ -136,12 +137,12 @@ bool SimpleReverbAudioProcessor::isBusesLayoutSupported (const BusesLayout& layo
 
 void SimpleReverbAudioProcessor::updateReverbSettings()
 {
-    params.roomSize   = apvts.getParameter ("size")->getValue();
-    params.damping    = apvts.getParameter ("damp")->getValue();
-    params.width      = apvts.getParameter ("width")->getValue();
-    params.wetLevel   = apvts.getParameter ("dw")->getValue();
-    params.dryLevel   = 1.0f - apvts.getParameter ("dw")->getValue();
-    params.freezeMode = apvts.getParameter ("freeze")->getValue();
+    params.roomSize   = apvts.getParameter (ParamNames::size)->getValue();
+    params.damping    = apvts.getParameter (ParamNames::damp)->getValue();
+    params.width      = apvts.getParameter (ParamNames::width)->getValue();
+    params.wetLevel   = apvts.getParameter (ParamNames::dryWet)->getValue();
+    params.dryLevel   = 1.0f - apvts.getParameter (ParamNames::dryWet)->getValue();
+    params.freezeMode = apvts.getParameter (ParamNames::freeze)->getValue();
 
     reverb.setParameters (params);
 }
@@ -213,8 +214,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
         return text.getFloatValue();
     };
 
-    layout.add (std::make_unique<juce::AudioParameterFloat> ("size",
-                                                             "size",
+    layout.add (std::make_unique<juce::AudioParameterFloat> (ParamNames::size,
+                                                             ParamNames::size,
                                                              range,
                                                              defaultValue,
                                                              juce::String(),
@@ -222,8 +223,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
                                                              stringFromValue,
                                                              valueFromString));
 
-    layout.add (std::make_unique<juce::AudioParameterFloat> ("damp",
-                                                             "damp",
+    layout.add (std::make_unique<juce::AudioParameterFloat> (ParamNames::damp,
+                                                             ParamNames::damp,
                                                              range,
                                                              defaultValue,
                                                              juce::String(),
@@ -232,8 +233,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
                                                              valueFromString));
 
 
-    layout.add (std::make_unique<juce::AudioParameterFloat> ("width",
-                                                             "width",
+    layout.add (std::make_unique<juce::AudioParameterFloat> (ParamNames::width,
+                                                             ParamNames::width,
                                                              range,
                                                              defaultValue,
                                                              juce::String(),
@@ -241,8 +242,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
                                                              stringFromValue,
                                                              valueFromString));
 
-    layout.add (std::make_unique<juce::AudioParameterFloat> ("dw",
-                                                             "dw",
+    layout.add (std::make_unique<juce::AudioParameterFloat> (ParamNames::dryWet,
+                                                             ParamNames::dryWet,
                                                              range,
                                                              defaultValue,
                                                              juce::String(),
@@ -250,7 +251,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
                                                              stringFromValue,
                                                              valueFromString));
 
-    layout.add (std::make_unique<juce::AudioParameterBool> ("freeze", "freeze", false));
+    layout.add (std::make_unique<juce::AudioParameterBool> (ParamNames::freeze, ParamNames::freeze, false));
 
     return layout;
 }


### PR DESCRIPTION
To avoid parameter names typos, do not use string literals.